### PR TITLE
Make record and union comparisons return the correct value

### DIFF
--- a/lib/Cauterize/C11Ref/LibCFile/Comparators.hs
+++ b/lib/Cauterize/C11Ref/LibCFile/Comparators.hs
@@ -73,7 +73,7 @@ compareRecord fs = chompNewline [i|
 
 #{fieldComps}
 
-    return caut_ord_eq;
+    return _c_o;
 |]
   where
     fieldComps = intercalate "\n" $ map compareRecordField fs
@@ -101,7 +101,7 @@ compareUnion n fs = chompNewline [i|
 #{fieldComps}
     }
 
-    return caut_ord_eq;|]
+    return _c_o;|]
   where
     fieldComps = intercalate "\n" $ map (compareUnionField n) fs
 

--- a/lib/Cauterize/C11Ref/LibCFile/Comparators.hs
+++ b/lib/Cauterize/C11Ref/LibCFile/Comparators.hs
@@ -73,7 +73,7 @@ compareRecord fs = chompNewline [i|
 
 #{fieldComps}
 
-    return _c_o;
+    return caut_ord_eq;
 |]
   where
     fieldComps = intercalate "\n" $ map compareRecordField fs


### PR DESCRIPTION
Generated `union` and `record` comparison functions return `caut_ord_eq`, and not the actual comparison result.
