### PR TITLE
Update stack & cabal files

### DIFF
--- a/caut-c11-ref.cabal
+++ b/caut-c11-ref.cabal
@@ -10,7 +10,7 @@ library
   hs-source-dirs:      lib
   ghc-options:         -Wall
   default-language:    Haskell2010
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7 && <4.10,
                        cauterize >= 0.1.0.0,
                        containers,
                        file-embed,
@@ -36,7 +36,7 @@ executable caut-c11-ref
   hs-source-dirs:      bin
   main-is:             Main.hs
   ghc-options:         -Wall -O2 -threaded
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7 && <4.10,
                        caut-c11-ref,
                        cauterize >= 0.1.0.0,
                        optparse-applicative,

--- a/caut-c11-ref.cabal
+++ b/caut-c11-ref.cabal
@@ -11,7 +11,7 @@ library
   ghc-options:         -Wall
   default-language:    Haskell2010
   build-depends:       base >=4.7 && <4.10,
-                       cauterize >= 0.1.0.0,
+                       cauterize >= 1.0.0,
                        containers,
                        file-embed,
                        bytestring,
@@ -38,7 +38,7 @@ executable caut-c11-ref
   ghc-options:         -Wall -O2 -threaded
   build-depends:       base >=4.7 && <4.10,
                        caut-c11-ref,
-                       cauterize >= 0.1.0.0,
+                       cauterize >= 1.0.0,
                        optparse-applicative,
                        text,
                        filepath,

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,10 @@ packages:
 - '.'
 - location:
     git: https://github.com/cauterize-tools/cauterize.git
-    commit: bcd3ffefc677a02c0bbf95e7e806d1bf0b33d6dd
+    commit: v1.0.0
 - location:
     git: https://github.com/cauterize-tools/crucible.git
-    commit: b2125cf19e64411c08b10a26bd8dffa17e11ec0e
+    commit: v1.0.0
 extra-deps:
   - s-cargot-0.1.0.0
-resolver: lts-3.16
+resolver: lts-7.18

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,8 @@
 flags: {}
 packages:
 - '.'
-- location:
-    git: https://github.com/cauterize-tools/cauterize.git
-    commit: v1.0.0
-- location:
-    git: https://github.com/cauterize-tools/crucible.git
-    commit: v1.0.0
 extra-deps:
-  - s-cargot-0.1.0.0
+- s-cargot-0.1.0.0
+- git: https://github.com/cauterize-tools/cauterize.git
+  commit: v1.0.0
 resolver: lts-7.18

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,5 @@ packages:
 extra-deps:
 - s-cargot-0.1.0.0
 - git: https://github.com/cauterize-tools/cauterize.git
-  commit: v1.0.0
+  commit: e07434771d39961d89159add7fdacbedf1d9ff14
 resolver: lts-7.18


### PR DESCRIPTION
Particularly, update the cauterize dependency version. `caut-c11-ref` chokes on `.spec` files built with `cauterize v1.0.0`:

```
caut-c11-ref: "Unexpected vector body: [WFSList [WFSAtom (Ident \"fingerprint\"),WFSAtom (Hash ...```