### PR TITLE
Update stack & cauterize dependency

### DIFF
--- a/bin/Cauterize/C11Ref/Options.hs
+++ b/bin/Cauterize/C11Ref/Options.hs
@@ -3,13 +3,14 @@ module Cauterize.C11Ref.Options
   , Caut2C11Opts(..)
   ) where
 
+import Data.Monoid         ((<>))
 import Options.Applicative
 
 runWithOptions :: (Caut2C11Opts -> IO ()) -> IO ()
 runWithOptions fn = execParser options >>= fn
 
 data Caut2C11Opts = Caut2C11Opts
-  { specFile :: FilePath
+  { specFile        :: FilePath
   , outputDirectory :: FilePath
   } deriving (Show)
 

--- a/caut-c11-ref.cabal
+++ b/caut-c11-ref.cabal
@@ -10,7 +10,7 @@ library
   hs-source-dirs:      lib
   ghc-options:         -Wall
   default-language:    Haskell2010
-  build-depends:       base >=4.7 && <4.10,
+  build-depends:       base >=4.7 && <= 4.10.1.0,
                        cauterize >= 1.0.0,
                        containers,
                        file-embed,
@@ -36,7 +36,7 @@ executable caut-c11-ref
   hs-source-dirs:      bin
   main-is:             Main.hs
   ghc-options:         -Wall -O2 -threaded
-  build-depends:       base >=4.7 && <4.10,
+  build-depends:       base >=4.7 && <= 4.10.1.0,
                        caut-c11-ref,
                        cauterize >= 1.0.0,
                        optparse-applicative,

--- a/caut-c11-ref.cabal
+++ b/caut-c11-ref.cabal
@@ -10,8 +10,8 @@ library
   hs-source-dirs:      lib
   ghc-options:         -Wall
   default-language:    Haskell2010
-  build-depends:       base >=4.7 && <4.9,
-                       cauterize >= 0.1.0.0,
+  build-depends:       base >=4.7 && <4.10,
+                       cauterize >= 1.0.0,
                        containers,
                        file-embed,
                        bytestring,
@@ -36,9 +36,9 @@ executable caut-c11-ref
   hs-source-dirs:      bin
   main-is:             Main.hs
   ghc-options:         -Wall -O2 -threaded
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7 && <4.10,
                        caut-c11-ref,
-                       cauterize >= 0.1.0.0,
+                       cauterize >= 1.0.0,
                        optparse-applicative,
                        text,
                        filepath,

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,8 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- s-cargot-0.1.0.0
+- GraphSCC-1.0.4
+- s-cargot-0.1.2.0
 - git: https://github.com/cauterize-tools/cauterize.git
   commit: e07434771d39961d89159add7fdacbedf1d9ff14
-resolver: lts-7.18
+resolver: lts-10.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,8 @@
 flags: {}
 packages:
 - '.'
-- location:
-    git: https://github.com/cauterize-tools/cauterize.git
-    commit: bcd3ffefc677a02c0bbf95e7e806d1bf0b33d6dd
-- location:
-    git: https://github.com/cauterize-tools/crucible.git
-    commit: b2125cf19e64411c08b10a26bd8dffa17e11ec0e
 extra-deps:
-  - s-cargot-0.1.0.0
-resolver: lts-3.16
+- s-cargot-0.1.0.0
+- git: https://github.com/cauterize-tools/cauterize.git
+  commit: e07434771d39961d89159add7fdacbedf1d9ff14
+resolver: lts-7.18


### PR DESCRIPTION
- Depends on most recent `cauterize`.
- Updates stack resolver to LTS-10.3
- Fixes missing Data.Monoid.<>