### PR TITLE
Bring caut-c11-ref up to date

### DIFF
--- a/bin/Cauterize/C11Ref/Options.hs
+++ b/bin/Cauterize/C11Ref/Options.hs
@@ -3,13 +3,14 @@ module Cauterize.C11Ref.Options
   , Caut2C11Opts(..)
   ) where
 
+import Data.Monoid         ((<>))
 import Options.Applicative
 
 runWithOptions :: (Caut2C11Opts -> IO ()) -> IO ()
 runWithOptions fn = execParser options >>= fn
 
 data Caut2C11Opts = Caut2C11Opts
-  { specFile :: FilePath
+  { specFile        :: FilePath
   , outputDirectory :: FilePath
   } deriving (Show)
 

--- a/caut-c11-ref.cabal
+++ b/caut-c11-ref.cabal
@@ -10,8 +10,8 @@ library
   hs-source-dirs:      lib
   ghc-options:         -Wall
   default-language:    Haskell2010
-  build-depends:       base >=4.7 && <4.9,
-                       cauterize >= 0.1.0.0,
+  build-depends:       base >=4.7 && <= 4.10.1.0,
+                       cauterize >= 1.0.0,
                        containers,
                        file-embed,
                        bytestring,
@@ -36,7 +36,7 @@ executable caut-c11-ref
   hs-source-dirs:      bin
   main-is:             Main.hs
   ghc-options:         -Wall -O2 -threaded
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7 && <= 4.10.1.0,
                        caut-c11-ref,
                        cauterize >= 0.1.0.0,
                        optparse-applicative,

--- a/lib/Cauterize/C11Ref/LibCFile.hs
+++ b/lib/Cauterize/C11Ref/LibCFile.hs
@@ -31,7 +31,6 @@ fromSpec s = [chompNewline [i|
   #define R enum caut_status
   #define EI struct caut_encode_iter
   #define DI struct caut_decode_iter
-  #define FSET(FS,IX) ((FS) & (1ull << (IX)))
 |]
   , comment "schema hash"
   , [i|  hashtype_t const SCHEMA_HASH_#{ln} = { #{hashToBytes (S.specFingerprint s)} };|]

--- a/lib/Cauterize/C11Ref/LibCFile/Decoders.hs
+++ b/lib/Cauterize/C11Ref/LibCFile/Decoders.hs
@@ -77,15 +77,13 @@ enumerationDecoderBody n _ t = chompNewline [i|
     #{tag2c t} _c_tag;
     STATUS_CHECK(#{tag2decodefn t}(_c_iter, &_c_tag));
 
-    if (#{lsym} < _c_tag) {
+    if (_c_tag < ENUM_MIN_VAL_#{n} || _c_tag > ENUM_MAX_VAL_#{n}) {
       return caut_status_enumeration_out_of_range;
     }
 
     *_c_obj = (enum #{n})_c_tag;
 
     return caut_status_ok;|]
-  where
-    lsym = "ENUM_MAX_VAL_" ++ n
 
 recordDecoderBody :: [S.Field] -> String
 recordDecoderBody fs =
@@ -101,11 +99,12 @@ combinationDecoderBody n fs fr =
   in intercalate "\n" $ (decodeFlags : checkFlags : decodeFields) ++ ["", "    return caut_status_ok;"]
 
 unionDecoderBody :: String -> [S.Field] -> C.Tag -> String
-unionDecoderBody n fs tr = chompNewline [i|
+unionDecoderBody n fs tr =
+  chompNewline [i|
     #{tag2c tr} _temp_tag;
     STATUS_CHECK(#{tag2decodefn tr}(_c_iter, &_temp_tag));
 
-    if (_temp_tag >= UNION_NUM_FIELDS_#{n}) {
+    if (_temp_tag < UNION_MIN_TAG_VALUE_#{n} || _temp_tag > UNION_MAX_TAG_VALUE_#{n}) {
       return caut_status_invalid_tag;
     } else {
       _c_obj->_tag = (enum #{n}_tag)_temp_tag;

--- a/lib/Cauterize/C11Ref/LibCFile/Decoders.hs
+++ b/lib/Cauterize/C11Ref/LibCFile/Decoders.hs
@@ -128,7 +128,7 @@ decodeField S.EmptyField { S.fieldName = n, S.fieldIndex = ix } =
 decodeCombField :: S.Field -> String
 decodeCombField f@S.EmptyField {} = "    " ++ decodeField f
 decodeCombField f@S.DataField { S.fieldIndex = ix } = chompNewline [i|
-    if (FSET(_c_obj->_flags, #{ix})) { #{decodeField f} }|]
+    if ((_c_obj->_flags) & (1ull << (#{ix})) { #{decodeField f} }|]
 
 decodeUnionField :: String -> S.Field -> String
 decodeUnionField n f = [i|    case #{n}_tag_#{ident2str $ S.fieldName f}: #{decodeField f} break;|]

--- a/lib/Cauterize/C11Ref/LibCFile/Encoders.hs
+++ b/lib/Cauterize/C11Ref/LibCFile/Encoders.hs
@@ -172,7 +172,7 @@ encodeField S.EmptyField { S.fieldName = n, S.fieldIndex = ix } =
 encodeCombField :: S.Field -> String
 encodeCombField f@S.EmptyField {} = "    " ++ encodeField f
 encodeCombField f@S.DataField { S.fieldIndex = ix } = chompNewline [i|
-    if (FSET(_c_obj->_flags, #{ix})) { #{encodeField f} }|]
+    if ((_c_obj->_flags) & (1ull << #{ix})) { #{encodeField f} }|]
 
 encodeUnionField :: String -> S.Field -> String
 encodeUnionField n f = [i|    case #{n}_tag_#{ident2str $ S.fieldName f}: #{encodeField f} break;|]

--- a/lib/Cauterize/C11Ref/LibCMessageFile.hs
+++ b/lib/Cauterize/C11Ref/LibCMessageFile.hs
@@ -26,7 +26,6 @@ fromSpec s = [chompNewline [i|
   #define R enum caut_status
   #define EI struct caut_encode_iter
   #define DI struct caut_decode_iter
-  #define FSET(FS,IX) ((FS) & (1ull << (IX)))
 |]
   , comment "type descriptors"
   , chompNewline [i|

--- a/lib/Cauterize/C11Ref/LibHFile.hs
+++ b/lib/Cauterize/C11Ref/LibHFile.hs
@@ -24,6 +24,10 @@ fromSpec s = [chompNewline [i|
   #ifndef #{guardSym}
   #define #{guardSym}
 
+  #ifdef __cplusplus
+  extern "C" {
+  #endif
+
   #include "cauterize.h"
 |]
   , comment "library meta information"
@@ -52,6 +56,10 @@ fromSpec s = [chompNewline [i|
 
   , blankLine
   , chompNewline [i|
+  #ifdef __cplusplus
+  }
+  #endif
+
   #endif /* #{guardSym} */
 |]
   ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,5 +5,5 @@ extra-deps:
 - GraphSCC-1.0.4
 - s-cargot-0.1.2.0
 - git: https://github.com/cauterize-tools/cauterize.git
-  commit: 7d44a8e2c027a93d7937b29aa9915a082919f6c5
+  commit: e07434771d39961d89159add7fdacbedf1d9ff14
 resolver: lts-10.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,9 @@
 flags: {}
 packages:
 - '.'
-- location:
-    git: https://github.com/cauterize-tools/cauterize.git
-    commit: bcd3ffefc677a02c0bbf95e7e806d1bf0b33d6dd
-- location:
-    git: https://github.com/cauterize-tools/crucible.git
-    commit: b2125cf19e64411c08b10a26bd8dffa17e11ec0e
 extra-deps:
-  - s-cargot-0.1.0.0
-resolver: lts-3.16
+- GraphSCC-1.0.4
+- s-cargot-0.1.2.0
+- git: https://github.com/cauterize-tools/cauterize.git
+  commit: 7d44a8e2c027a93d7937b29aa9915a082919f6c5
+resolver: lts-10.3


### PR DESCRIPTION
- Updates dependencies
- Makes [en/de]coding compatible with specs generated with 0 or 1 based tag/enum values
- Eliminates some common sources of compiler warnings:
  - Useless comparisons
  - Unused macros